### PR TITLE
Add s3-file-field

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # cookiecutter-django-girder
 
 Usage: `cookiecutter https://github.com/girder/cookiecutter-django-girder.git`
+
+## Delete example migration
+
+The cookiecutter includes some initial models and migrations as an example of how models should be written.
+After you have created your first models and are ready to commit your code, you should **delete** `{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/migrations/0001_initial.py` and run `./manage.py makemigrations` to create a new initial migration.
+Otherwise, the example models will be permanently included in the migration history.

--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -1,11 +1,5 @@
 # {{ cookiecutter.project_name }}
 
-## TODO Delete the example migration!
-
-The cookiecutter includes some initial models and migrations as an example of how models should be written.
-After you have created your first models and are ready to commit your code, you should **delete** `{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/migrations/0001_initial.py` and run `./manage.py makemigrations` to create a new initial migration.
-Otherwise, the example models will be permanently included in the migration history.
-
 ## Develop with Docker (recommended)
 
 This is the simplest configuration for developers to start with.

--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -5,7 +5,7 @@
 This is the simplest configuration for developers to start with.
 ### Initial Setup
 1. Run `docker-compose run --rm django ./manage.py migrate`
-2. Run `docker-compose run --rm django ./manage.py createsuperuser` 
+2. Run `docker-compose run --rm django ./manage.py createsuperuser`
    and follow the prompts to create your own user
 
 ### Run Application
@@ -40,6 +40,11 @@ but allows developers to run the Python code on their native system.
    2. `celery worker --app {{ cookiecutter.pkg_name }}.celery --loglevel info --without-heartbeat`
 2. When finished, run `docker-compose stop`
 
+## TODO Delete the example migration!
+
+The cookiecutter includes some initial models and migrations as an example of how models should be written.
+After you have created your first models and are ready to commit your code, you should **delete** `{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/migrations/0001_initial.py` and run `./manage.py makemigrations` to create a new initial migration.
+Otherwise, the example models will be permanently included in the migration history.
 
 TODO: Document:
   DOCKER_POSTGRES_PORT (with DJANGO_DATABASE_URL)

--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -1,5 +1,11 @@
 # {{ cookiecutter.project_name }}
 
+## TODO Delete the example migration!
+
+The cookiecutter includes some initial models and migrations as an example of how models should be written.
+After you have created your first models and are ready to commit your code, you should **delete** `{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/migrations/0001_initial.py` and run `./manage.py makemigrations` to create a new initial migration.
+Otherwise, the example models will be permanently included in the migration history.
+
 ## Develop with Docker (recommended)
 
 This is the simplest configuration for developers to start with.
@@ -39,12 +45,6 @@ but allows developers to run the Python code on their native system.
    1. `./manage.py runserver`
    2. `celery worker --app {{ cookiecutter.pkg_name }}.celery --loglevel info --without-heartbeat`
 2. When finished, run `docker-compose stop`
-
-## TODO Delete the example migration!
-
-The cookiecutter includes some initial models and migrations as an example of how models should be written.
-After you have created your first models and are ready to commit your code, you should **delete** `{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/migrations/0001_initial.py` and run `./manage.py makemigrations` to create a new initial migration.
-Otherwise, the example models will be permanently included in the migration history.
 
 TODO: Document:
   DOCKER_POSTGRES_PORT (with DJANGO_DATABASE_URL)

--- a/{{ cookiecutter.project_slug }}/setup.py
+++ b/{{ cookiecutter.project_slug }}/setup.py
@@ -44,6 +44,7 @@ setup(
         'django-extensions',
         'django-filter',
         'django-girders',
+        'django-s3-file-field',
         'djangorestframework',
         'drf-extensions',
         'drf-yasg',

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/settings.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/settings.py
@@ -8,6 +8,7 @@ from django_girders.configuration import (
     DevelopmentBaseConfiguration,
     HerokuProductionBaseConfiguration,
     ProductionBaseConfiguration,
+    TestingBaseConfiguration,
 )
 
 
@@ -23,6 +24,10 @@ class {{ cookiecutter.pkg_name.split('_')|map('capitalize')|join('') }}Config(Co
 
 
 class DevelopmentConfiguration({{ cookiecutter.pkg_name.split('_')|map('capitalize')|join('') }}Config, DevelopmentBaseConfiguration):
+    pass
+
+
+class TestingConfiguration({{ cookiecutter.pkg_name.split('_')|map('capitalize')|join('') }}Config, TestingBaseConfiguration):
     pass
 
 

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/settings.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/settings.py
@@ -8,7 +8,6 @@ from django_girders.configuration import (
     DevelopmentBaseConfiguration,
     HerokuProductionBaseConfiguration,
     ProductionBaseConfiguration,
-    TestingBaseConfiguration,
 )
 
 
@@ -20,14 +19,10 @@ class {{ cookiecutter.pkg_name.split('_')|map('capitalize')|join('') }}Config(Co
 
     @staticmethod
     def before_binding(configuration: ComposedConfiguration) -> None:
-        configuration.INSTALLED_APPS += ['{{ cookiecutter.pkg_name }}.{{ cookiecutter.first_app_name }}.apps.{{ cookiecutter.first_app_name.split('_')|map('capitalize')|join('') }}Config']
+        configuration.INSTALLED_APPS += ['{{ cookiecutter.pkg_name }}.{{ cookiecutter.first_app_name }}.apps.{{ cookiecutter.first_app_name.split('_')|map('capitalize')|join('') }}Config', 's3_file_field']
 
 
 class DevelopmentConfiguration({{ cookiecutter.pkg_name.split('_')|map('capitalize')|join('') }}Config, DevelopmentBaseConfiguration):
-    pass
-
-
-class TestingConfiguration({{ cookiecutter.pkg_name.split('_')|map('capitalize')|join('') }}Config, TestingBaseConfiguration):
     pass
 
 

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/settings.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/settings.py
@@ -20,7 +20,10 @@ class {{ cookiecutter.pkg_name.split('_')|map('capitalize')|join('') }}Config(Co
 
     @staticmethod
     def before_binding(configuration: ComposedConfiguration) -> None:
-        configuration.INSTALLED_APPS += ['{{ cookiecutter.pkg_name }}.{{ cookiecutter.first_app_name }}.apps.{{ cookiecutter.first_app_name.split('_')|map('capitalize')|join('') }}Config', 's3_file_field']
+        configuration.INSTALLED_APPS += [
+            '{{ cookiecutter.pkg_name }}.{{ cookiecutter.first_app_name }}.apps.{{ cookiecutter.first_app_name.split('_')|map('capitalize')|join('') }}Config',
+            's3_file_field',
+        ]
 
 
 class DevelopmentConfiguration({{ cookiecutter.pkg_name.split('_')|map('capitalize')|join('') }}Config, DevelopmentBaseConfiguration):

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/urls.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/urls.py
@@ -24,6 +24,7 @@ urlpatterns = [
     path('api/v1/', include(router.urls)),
     path('api/docs/redoc', schema_view.with_ui('redoc'), name='docs-redoc'),
     path('api/docs/swagger', schema_view.with_ui('swagger'), name='docs-swagger'),
+    path('api/s3-upload/', include('s3_file_field.urls')),
     path('summary/', image_summary, name='image-summary'),
     path('gallery/', GalleryView.as_view(), name='gallery'),
 ]

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/migrations/0001_initial.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/migrations/0001_initial.py
@@ -17,17 +17,40 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Image',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('created', django_extensions.db.fields.CreationDateTimeField(auto_now_add=True, verbose_name='created')),
-                ('modified', django_extensions.db.fields.ModificationDateTimeField(auto_now=True, verbose_name='modified')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True, primary_key=True, serialize=False, verbose_name='ID'
+                    ),
+                ),
+                (
+                    'created',
+                    django_extensions.db.fields.CreationDateTimeField(
+                        auto_now_add=True, verbose_name='created'
+                    ),
+                ),
+                (
+                    'modified',
+                    django_extensions.db.fields.ModificationDateTimeField(
+                        auto_now=True, verbose_name='modified'
+                    ),
+                ),
                 ('name', models.CharField(max_length=255)),
-                ('blob', s3_file_field.fields.S3FileField(max_length=2000, upload_to=s3_file_field.fields.S3FileField.uuid_prefix_filename)),
+                (
+                    'blob',
+                    s3_file_field.fields.S3FileField(
+                        max_length=2000,
+                        upload_to=s3_file_field.fields.S3FileField.uuid_prefix_filename,
+                    ),
+                ),
                 ('checksum', models.CharField(blank=True, max_length=128, null=True)),
-                ('owner', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+                (
+                    'owner',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL
+                    ),
+                ),
             ],
-            options={
-                'get_latest_by': 'modified',
-                'abstract': False,
-            },
+            options={'get_latest_by': 'modified', 'abstract': False},
         ),
     ]

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/migrations/0001_initial.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/migrations/0001_initial.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.db import migrations, models
 import django.db.models.deletion
 import django_extensions.db.fields
+import s3_file_field.fields
 
 
 class Migration(migrations.Migration):
@@ -16,34 +17,17 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Image',
             fields=[
-                (
-                    'id',
-                    models.AutoField(
-                        auto_created=True, primary_key=True, serialize=False, verbose_name='ID'
-                    ),
-                ),
-                (
-                    'created',
-                    django_extensions.db.fields.CreationDateTimeField(
-                        auto_now_add=True, verbose_name='created'
-                    ),
-                ),
-                (
-                    'modified',
-                    django_extensions.db.fields.ModificationDateTimeField(
-                        auto_now=True, verbose_name='modified'
-                    ),
-                ),
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('created', django_extensions.db.fields.CreationDateTimeField(auto_now_add=True, verbose_name='created')),
+                ('modified', django_extensions.db.fields.ModificationDateTimeField(auto_now=True, verbose_name='modified')),
                 ('name', models.CharField(max_length=255)),
-                ('blob', models.FileField(upload_to='')),
+                ('blob', s3_file_field.fields.S3FileField(max_length=2000, upload_to=s3_file_field.fields.S3FileField.uuid_prefix_filename)),
                 ('checksum', models.CharField(blank=True, max_length=128, null=True)),
-                (
-                    'owner',
-                    models.ForeignKey(
-                        on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL
-                    ),
-                ),
+                ('owner', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
             ],
-            options={'get_latest_by': 'modified', 'abstract': False},
+            options={
+                'get_latest_by': 'modified',
+                'abstract': False,
+            },
         ),
     ]

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/models/image.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/models/image.py
@@ -4,7 +4,6 @@ from typing import Optional
 from django.contrib.auth.models import User
 from django.db import models
 from django_extensions.db.models import TimeStampedModel
-
 from s3_file_field import S3FileField
 
 

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/models/image.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/models/image.py
@@ -5,10 +5,12 @@ from django.contrib.auth.models import User
 from django.db import models
 from django_extensions.db.models import TimeStampedModel
 
+from s3_file_field import S3FileField
+
 
 class Image(TimeStampedModel, models.Model):
     name = models.CharField(max_length=255)
-    blob = models.FileField()
+    blob = S3FileField()
     checksum = models.CharField(max_length=128, blank=True, null=True)
     owner = models.ForeignKey(User, on_delete=models.CASCADE)
     # TimeStampedModel also provides "created" and "modified" fields


### PR DESCRIPTION
The default `Image` model now uses an `S3FileField` to store the file.

The `README.md` is still missing one step, creating the `django-storage`
bucket in the Minio instance. This needs to be either added to the set
up instructions (which would be a rather obnoxious step during initial
setup) or the `girder/minio-nonroot` image should include that bucket by
default.