### PR TITLE
Make test factory registration less fragile

### DIFF
--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/tests/conftest.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/tests/conftest.py
@@ -1,10 +1,14 @@
 import pytest
+from pytest_factoryboy import register
 from rest_framework.test import APIClient
 
-# Names must be imported into conftest, importing for side effects is not sufficient
-from .factories import *  # noqa: F401,F403
+from .factories import ImageFactory, UserFactory
 
 
 @pytest.fixture
 def api_client():
     return APIClient()
+
+
+register(ImageFactory)
+register(UserFactory)

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/tests/factories.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/tests/factories.py
@@ -1,11 +1,9 @@
 from django.contrib.auth.models import User
 import factory.django
-from pytest_factoryboy import register
 
 from {{ cookiecutter.pkg_name }}.{{ cookiecutter.first_app_name }}.models import Image
 
 
-@register
 class UserFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = User
@@ -16,7 +14,6 @@ class UserFactory(factory.django.DjangoModelFactory):
     last_name = factory.Faker('last_name')
 
 
-@register
 class ImageFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Image


### PR DESCRIPTION
This removes the use of pytest_factorboy's @factory decorator as a matter of policy, as it's too fragile. Factories must be explicitly imported (if they are defined elsewhere) and registered in conftest.py.

The register function / decorator works by defining a new fixture function into the local Python file namespace. Pytest only automatically detects and registers global fixtures if they are within the namespace of conftest.py; fixtures defined as part of an import of other files are not registered.