### PR TITLE
Add configuration related django-allauth

### DIFF
--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/settings.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/settings.py
@@ -18,6 +18,8 @@ class {{ cookiecutter.pkg_name.split('_')|map('capitalize')|join('') }}Config(Co
 
     BASE_DIR = Path(__file__).resolve(strict=True).parent.parent
 
+    SITE_ID = 1
+
     @staticmethod
     def before_binding(configuration: ComposedConfiguration) -> None:
         configuration.INSTALLED_APPS += [

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/urls.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
     path('api/s3-upload/', include('s3_file_field.urls')),
     path('summary/', image_summary, name='image-summary'),
     path('gallery/', GalleryView.as_view(), name='gallery'),
+    path('accounts/', include('allauth.urls')),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
Depends on https://github.com/girder/django-composed-configuration/pull/60.

I believe this works out of the box, but we could add more documentation regarding managing django-sites and social accounts or even just link out to allauth's documentation.