### PR TITLE
Use the "management" tag of the RabbitMQ image in Docker Compose

### DIFF
--- a/{{ cookiecutter.project_slug }}/docker-compose.yml
+++ b/{{ cookiecutter.project_slug }}/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - ${DOCKER_POSTGRES_PORT-5432}:5432
 
   rabbitmq:
-    image: rabbitmq:latest
+    image: rabbitmq:management
     ports:
       - ${DOCKER_RABBITMQ_PORT-5672}:5672
 


### PR DESCRIPTION
This provides additional tools for directly accessing RabbitMQ in development.