### PR TITLE
Move S3 upload endpoints under /v1

### DIFF
--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/urls.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/urls.py
@@ -21,7 +21,7 @@ schema_view = get_schema_view(
 urlpatterns = [
     path('accounts/', include('allauth.urls')),
     path('admin/', admin.site.urls),
-    path('api/s3-upload/', include('s3_file_field.urls')),
+    path('api/v1/s3-upload/', include('s3_file_field.urls')),
     path('api/v1/', include(router.urls)),
     path('api/docs/redoc', schema_view.with_ui('redoc'), name='docs-redoc'),
     path('api/docs/swagger', schema_view.with_ui('swagger'), name='docs-swagger'),


### PR DESCRIPTION
Without this change, the swagger UI view is wonky, showing `v1` and `s3-upload` as top-level tags, rather than combining them into one schema.