### PR TITLE
Pin django-minio-storage>=0.3.10

### DIFF
--- a/{{ cookiecutter.project_slug }}/setup.py
+++ b/{{ cookiecutter.project_slug }}/setup.py
@@ -57,8 +57,7 @@ setup(
         'sentry-sdk',
         # Development-only
         'django-debug-toolbar',
-        'django-minio-storage',
-        'minio<7',
+        'django-minio-storage>=0.3.10',
     ],
     extras_require={'dev': ['ipython', 'tox']},
 )


### PR DESCRIPTION
This fixes an incompatibility with minio 7.