### PR TITLE
Append / to end of redoc and swagger URLs

### DIFF
--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/urls.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/urls.py
@@ -23,8 +23,8 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/v1/s3-upload/', include('s3_file_field.urls')),
     path('api/v1/', include(router.urls)),
-    path('api/docs/redoc', schema_view.with_ui('redoc'), name='docs-redoc'),
-    path('api/docs/swagger', schema_view.with_ui('swagger'), name='docs-swagger'),
+    path('api/docs/redoc/', schema_view.with_ui('redoc'), name='docs-redoc'),
+    path('api/docs/swagger/', schema_view.with_ui('swagger'), name='docs-swagger'),
     path('summary/', image_summary, name='image-summary'),
     path('gallery/', GalleryView.as_view(), name='gallery'),
 ]


### PR DESCRIPTION
URL patterns should consistently have trailing slashes.