### PR TITLE
Include package data when installing the project

### DIFF
--- a/{{ cookiecutter.project_slug }}/MANIFEST.in
+++ b/{{ cookiecutter.project_slug }}/MANIFEST.in
@@ -1,0 +1,2 @@
+# Include any data files such as templates or static assets in the source distribution
+graft {{ cookiecutter.pkg_name }}

--- a/{{ cookiecutter.project_slug }}/setup.py
+++ b/{{ cookiecutter.project_slug }}/setup.py
@@ -34,6 +34,7 @@ setup(
     ],
     python_requires='>=3.8',
     packages=find_packages(),
+    include_package_data=True,
     install_requires=[
         'celery',
         'django',


### PR DESCRIPTION
This is necessary to support non-development installs of the project.