### PR TITLE
Add fix for ZSH source of dev/source-native-env.sh

### DIFF
--- a/{{ cookiecutter.project_slug }}/dev/source-native-env.sh
+++ b/{{ cookiecutter.project_slug }}/dev/source-native-env.sh
@@ -1,13 +1,12 @@
 # This file must be sourced, not run
 DOTENV_FILE="$( dirname "${BASH_SOURCE[0]}" )/.env.docker-compose-native"
 
-# This is a hack to make sourcing source-native-env.sh compliant with shells
-# like ZSH See: https://github.com/girder/cookiecutter-django-girder/issues/1
+# This is a hack to make sourcing source-native-env.sh compliant with ZSH
+# See: https://github.com/girder/cookiecutter-django-girder/issues/1
 if [[ ! -r $DOTENV_FILE ]]; then
-  if [[ -r dev/.env.docker-compose-native ]]; then
-    DOTENV_FILE=dev/.env.docker-compose-native
-  else
-    echo >&2 "Could not find .env.docker-compose-native, are you sourcing from the root directory?"
+  DOTENV_FILE=$( dirname $0:A )/.env.docker-compose-native
+  if [[ ! -r $DOTENV_FILE ]]; then
+    echo >&2 "Could not find .env.docker-compose-native, try sourcing $0 from the dev/ directory."
     return
   fi
 fi

--- a/{{ cookiecutter.project_slug }}/dev/source-native-env.sh
+++ b/{{ cookiecutter.project_slug }}/dev/source-native-env.sh
@@ -1,5 +1,17 @@
 # This file must be sourced, not run
 DOTENV_FILE="$( dirname "${BASH_SOURCE[0]}" )/.env.docker-compose-native"
+
+# This is a hack to make sourcing source-native-env.sh compliant with shells
+# like ZSH See: https://github.com/girder/cookiecutter-django-girder/issues/1
+if [[ ! -r $DOTENV_FILE ]]; then
+  if [[ -r dev/.env.docker-compose-native ]]; then
+    DOTENV_FILE=dev/.env.docker-compose-native
+  else
+    echo >&2 "Could not find .env.docker-compose-native, are you sourcing from the root directory?"
+    return
+  fi
+fi
+
 while read -r VAR; do
   export "${VAR?}"
 done < "${DOTENV_FILE}"


### PR DESCRIPTION
Closes #1

This is a practical solution to the most common (i.e. documented) approach to sourcing dev/source-native-env.sh as outlined in the documentation. While it is not elegant,  it removes a common stumbling block for those using shells like ZSH. 