### PR TITLE
Remove Image code if example_models does not equal 'yes'

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,16 @@
 * `pkg_name`: A Python module name (which must be underscore-delimited), used for the top-level Django project.
 * `first_app_name`: A Python module name, used for the initial local Django app within this project. It's suggested that you use `core`, unless you know you will be creating multiple apps.
 * `site_domain`: The fully-qualified domain name of the target production deployment.
+* `example_models`: Include (or exclude) example Image model
 
 ## Delete example model migration
 
-The cookiecutter includes some initial models and an associated migration,
+The cookiecutter includes some initial models, templates, and an associated migration,
 as an example of how models should be written.
 
-After you have created your first models and are ready to commit your code, you should **delete**
-`{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/migrations/0002_initial_models.py`
-and run `./manage.py makemigrations` to create a new initial migration for your actual models.
-Otherwise, the example models will be permanently included in the migration history.
+If you opt to include these models (see: `example_models`) and after you have
+created your first models you should **delete** `{{ cookiecutter.pkg_name }}/{{
+cookiecutter.first_app_name }}/migrations/0002_initial_models.py` and run
+`./manage.py makemigrations` to create a new initial migration for your actual
+models. Otherwise, the example models will be permanently included in the
+migration history.

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -3,5 +3,6 @@
   "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}",
   "pkg_name": "{{ cookiecutter.project_slug.replace('-', '_') }}",
   "first_app_name": "core",
-  "site_domain": "{{ cookiecutter.project_slug }}.test"
+  "site_domain": "{{ cookiecutter.project_slug }}.test",
+  "example_models": "yes"
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+import os
+import shutil
+
+
+EXAMPLE_MODELS_REMOVE = [
+    '{{ cookiecutter.project_slug }}/{{ cookiecutter.first_app_name }}/admin/image.py',
+    '{{ cookiecutter.project_slug }}/{{ cookiecutter.first_app_name }}/migrations/0002_initial_models.py',
+    '{{ cookiecutter.project_slug }}/{{ cookiecutter.first_app_name }}/models/image.py',
+    '{{ cookiecutter.project_slug }}/{{ cookiecutter.first_app_name }}/rest/image.py',
+    '{{ cookiecutter.project_slug }}/{{ cookiecutter.first_app_name }}/templates/gallery.html',
+    '{{ cookiecutter.project_slug }}/{{ cookiecutter.first_app_name }}/templates/summary.html',
+    '{{ cookiecutter.project_slug }}/{{ cookiecutter.first_app_name }}/tests/test_image.py'
+]
+
+def _delete_resource(resource):
+    if os.path.isfile(resource):
+        os.remove(resource)
+    elif os.path.isdir(resource):
+        shutil.rmtree(resource)
+
+def example_models_hook():
+    for path in EXAMPLE_MODELS_REMOVE:
+        _delete_resource(path)
+
+def run_hooks():
+    if '{{ cookiecutter.example_models }}' != 'yes':
+        example_models_hook()
+
+if __name__ == "__main__":
+    run_hooks()

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/urls.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/urls.py
@@ -5,11 +5,17 @@ from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
 from rest_framework import permissions, routers
 
+{% if cookiecutter.example_models == 'yes' -%}
 from {{ cookiecutter.pkg_name }}.{{ cookiecutter.first_app_name }}.rest import ImageViewSet
 from {{ cookiecutter.pkg_name }}.{{ cookiecutter.first_app_name }}.views import GalleryView, image_summary
 
+{% endif -%}
+
 router = routers.SimpleRouter()
+{% if cookiecutter.example_models == 'yes' -%}
 router.register(r'images', ImageViewSet)
+
+{% endif -%}
 
 # OpenAPI generation
 schema_view = get_schema_view(
@@ -26,8 +32,10 @@ urlpatterns = [
     path('api/v1/', include(router.urls)),
     path('api/docs/redoc/', schema_view.with_ui('redoc'), name='docs-redoc'),
     path('api/docs/swagger/', schema_view.with_ui('swagger'), name='docs-swagger'),
+{%- if cookiecutter.example_models == 'yes' %}
     path('summary/', image_summary, name='image-summary'),
     path('gallery/', GalleryView.as_view(), name='gallery'),
+{%- endif %}
 ]
 
 if settings.DEBUG:

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/admin/__init__.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/admin/__init__.py
@@ -1,3 +1,5 @@
+{% if cookiecutter.example_models == 'yes' -%}
 from .image import ImageAdmin
 
 __all__ = ['ImageAdmin']
+{% endif -%}

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/models/__init__.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/models/__init__.py
@@ -1,3 +1,5 @@
+{% if cookiecutter.example_models == 'yes' -%}
 from .image import Image
 
 __all__ = ['Image']
+{%- endif %}

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/rest/__init__.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/rest/__init__.py
@@ -1,3 +1,5 @@
+{% if cookiecutter.example_models == 'yes' -%}
 from .image import ImageViewSet
 
 __all__ = ['ImageViewSet']
+{%- endif %}

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/tasks.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/tasks.py
@@ -1,5 +1,6 @@
 from celery import shared_task
 
+{% if cookiecutter.example_models == 'yes' -%}
 from {{ cookiecutter.pkg_name }}.{{ cookiecutter.first_app_name }}.models import Image
 
 
@@ -8,3 +9,4 @@ def image_compute_checksum(image_id: int):
     image = Image.objects.get(pk=image_id)
     image.compute_checksum()
     image.save()
+{% endif -%}

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/tests/conftest.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/tests/conftest.py
@@ -2,7 +2,11 @@ import pytest
 from pytest_factoryboy import register
 from rest_framework.test import APIClient
 
+{% if cookiecutter.example_models == 'yes' -%}
 from .factories import ImageFactory, UserFactory
+{%- else -%}
+from .factories import UserFactory
+{%- endif %}
 
 
 @pytest.fixture
@@ -17,5 +21,7 @@ def authenticated_api_client(user) -> APIClient:
     return client
 
 
+{% if cookiecutter.example_models == 'yes' -%}
 register(ImageFactory)
+{% endif -%}
 register(UserFactory)

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/tests/factories.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/tests/factories.py
@@ -1,9 +1,11 @@
 from django.contrib.auth.models import User
 import factory.django
 
+{% if cookiecutter.example_models == 'yes' -%}
 from {{ cookiecutter.pkg_name }}.{{ cookiecutter.first_app_name }}.models import Image
 
 
+{% endif -%}
 class UserFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = User
@@ -14,6 +16,7 @@ class UserFactory(factory.django.DjangoModelFactory):
     last_name = factory.Faker('last_name')
 
 
+{% if cookiecutter.example_models == 'yes' -%}
 class ImageFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Image
@@ -21,3 +24,4 @@ class ImageFactory(factory.django.DjangoModelFactory):
     name = factory.Faker('file_name', category='image')
     blob = factory.django.FileField(data=b'fakeimagebytes', filename='fake.png')
     owner = factory.SubFactory(UserFactory)
+{%- endif %}

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/views.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/views.py
@@ -3,6 +3,7 @@ from django.db.models import Count, Q
 from django.shortcuts import render
 from django.views.generic import ListView
 
+{% if cookiecutter.example_models == 'yes' -%}
 from {{ cookiecutter.pkg_name }}.{{ cookiecutter.first_app_name }}.models import Image
 
 
@@ -23,3 +24,4 @@ def image_summary(request):
             )
         },
     )
+{%- endif %}


### PR DESCRIPTION
Closes #44

Adds a `example_models` variable which toggles inclusion of the Image model and related views, rest endpoints, admin, celery tasks, test configs and urls. 

TODO:
  + [x] Add a post_gen_project.py file following something like [this comment](https://github.com/cookiecutter/cookiecutter/issues/723#issuecomment-229531213) that removes:
    + core/admin/image.py
    + core/migrations/0002_initial_models.py
    + core/models/image.py
    + core/rest/image.py
    + core/templates/gallery.html
    + core/templates/summary.html
    + core/tests/test_image.py