### PR TITLE
Refactor the source-native-env.sh script

### DIFF
--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -31,17 +31,17 @@ but allows developers to run Python code on their native system.
    [`psycopg2` build prerequisites](https://www.psycopg.org/docs/install.html#build-prerequisites)
 4. Create and activate a new Python virtualenv
 5. Run `pip install -e .[dev]`
-6. Run `source ./dev/source-native-env.sh`
+6. Run `source ./dev/export-env.sh`
 7. Run `./manage.py migrate`
 8. Run `./manage.py createsuperuser` and follow the prompts to create your own user
 
 ### Run Application
 1.  Ensure `docker-compose -f ./docker-compose.yml up -d` is still active
 2. Run:
-   1. `source ./dev/source-native-env.sh`
+   1. `source ./dev/export-env.sh`
    2. `./manage.py runserver`
 3. Run in a separate terminal:
-   1. `source ./dev/source-native-env.sh`
+   1. `source ./dev/export-env.sh`
    2. `celery --app {{ cookiecutter.pkg_name }}.celery worker --loglevel INFO --without-heartbeat`
 4. When finished, run `docker-compose stop`
 

--- a/{{ cookiecutter.project_slug }}/dev/export-env.sh
+++ b/{{ cookiecutter.project_slug }}/dev/export-env.sh
@@ -1,0 +1,29 @@
+# Export environment variables from the .env file in the first argument.
+# If no argument is given, default to "dev/.env.docker-compose-native".
+# This file must be sourced, not run.
+
+if [ -n "$1" ]; then
+  # If an argument was provided, use it as the .env file
+  _dotenv_file="$1"
+else
+  # Otherwise, use the default .env file
+  if [ -n "$ZSH_VERSION" ]; then
+    # ZSH has a different way to get the directory of the current script
+    _dotenv_dir="$0:A:h"
+  else
+    # Assume this is Bash
+    _dotenv_dir="$( dirname "${BASH_SOURCE[0]}" )"
+  fi
+  _dotenv_file="${_dotenv_dir}/.env.docker-compose-native"
+fi
+
+# Export all assignments in the $_dotenv_file
+# Using "set -a" allows .env files with spaces or comments to work seamlessly
+# https://stackoverflow.com/a/45971167
+set -a
+. "$_dotenv_file"
+set +a
+
+# Clean up, since sourcing this leaks any shell variables
+unset _dotenv_dir
+unset _dotenv_file

--- a/{{ cookiecutter.project_slug }}/dev/source-native-env.sh
+++ b/{{ cookiecutter.project_slug }}/dev/source-native-env.sh
@@ -1,5 +1,0 @@
-# This file must be sourced, not run
-DOTENV_FILE="$( dirname "${BASH_SOURCE[0]}" )/.env.docker-compose-native"
-while read -r VAR; do
-  export "${VAR?}"
-done < "${DOTENV_FILE}"


### PR DESCRIPTION
This provides several improvements:
* Support for ZSH
* Support for empty lines in the .env file
* Support for comments in the .env file
* Allows a different .env file to be passed as an argument
* Cleans up internal shell variables
* Rename to `export-env.sh`, to clarify behavior and reflect the more general capabilities

Fixes #1