### PR TITLE
Use a simpler approach to prevent pytest errors with no example_models

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,11 @@ Once you've adapted the example code to your own project's needs, you should **d
 `{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/migrations/0002_initial_models.py` 
 and run `./manage.py makemigrations` to create a new initial migration for your actual models.
 Otherwise, the example models will be permanently included in the migration history.
+
+### Without `include_example_code`
+
+If `include_example_code` is disabled, you may wish to make some small changes as your project
+grows.
+
+Once pytest tests are added, add / uncomment `envlist = test` in
+`{{ cookiecutter.project_slug }}/tox.ini`.

--- a/{{ cookiecutter.project_slug }}/tox.ini
+++ b/{{ cookiecutter.project_slug }}/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint,
-    test,
+    {% if cookiecutter.include_example_code != 'Y' %}# {% endif -%}test,
 
 [testenv:lint]
 skipsdist = true
@@ -50,10 +50,8 @@ deps =
     pytest-django
     pytest-factoryboy
     pytest-mock
-    # Note: implements --suppress-no-test-exit-code. Pass if there are no tests.
-    pytest-custom_exit_code
 commands =
-    pytest --suppress-no-test-exit-code {posargs}
+    pytest {posargs}
 
 [flake8]
 max-line-length = 100


### PR DESCRIPTION
I don't think most projects want to carry `pytest-custom-exit-code` as a long-term dependency. Rather than expect projects to remove the dependency and its CLI argument in the future, it's simpler to just give a (documented) single line of code to uncomment.