### PR TITLE
Remove noqa: F401 from minimal install

### DIFF
--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/tasks.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/tasks.py
@@ -1,5 +1,5 @@
-from celery import shared_task  # noqa: F401
-{%- if cookiecutter.include_example_code == 'Y'  %}
+{% if cookiecutter.include_example_code != 'Y' %}# {% endif -%}from celery import shared_task
+{%- if cookiecutter.include_example_code == 'Y' %}
 
 from {{ cookiecutter.pkg_name }}.{{ cookiecutter.first_app_name }}.models import Image
 

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/views.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/views.py
@@ -1,8 +1,9 @@
-from django.contrib.auth.models import User  # noqa: F401
-from django.db.models import Count, Q  # noqa: F401
-from django.shortcuts import render  # noqa: F401
-from django.views.generic import ListView  # noqa: F401
-{% if cookiecutter.include_example_code == 'Y' %}
+{% if cookiecutter.include_example_code == 'Y' -%}
+from django.contrib.auth.models import User
+from django.db.models import Count, Q
+from django.shortcuts import render
+from django.views.generic import ListView
+
 from {{ cookiecutter.pkg_name }}.{{ cookiecutter.first_app_name }}.models import Image
 
 


### PR DESCRIPTION
* Without example_code, exclude imports from `views.py`
  * These are too specific to be consistently generally useful.
* Comment out unused sample import, instead of `noqa`-ing it.
  * Downstreams may be scared to remove the `noqa` comment, but it should be obvious to uncomment the line.