### PR TITLE
Only install development requirements with the "dev" extra

### DIFF
--- a/{{ cookiecutter.project_slug }}/setup.py
+++ b/{{ cookiecutter.project_slug }}/setup.py
@@ -40,18 +40,24 @@ setup(
         'django',
         'django-admin-display',
         'django-allauth',
-        'django-composed-configuration[dev,prod]>=0.10.0',
         'django-configurations',
         'django-extensions',
         'django-filter',
         'django-oauth-toolkit',
-        'django-s3-file-field[minio,boto3]',
         'djangorestframework',
         'drf-yasg',
         # Production-only
+        'django-composed-configuration[prod]',
+        'django-s3-file-field[boto3]',
         'gunicorn',
-        # Development-only
-        'django-debug-toolbar',
     ],
-    extras_require={'dev': ['ipython', 'tox']},
+    extras_require={
+        'dev': [
+            'django-composed-configuration[dev]',
+            'django-debug-toolbar',
+            'django-s3-file-field[minio]',
+            'ipython',
+            'tox',
+        ]
+    },
 )

--- a/{{ cookiecutter.project_slug }}/tox.ini
+++ b/{{ cookiecutter.project_slug }}/tox.ini
@@ -45,6 +45,8 @@ passenv =
     DJANGO_MINIO_STORAGE_ACCESS_KEY
     DJANGO_MINIO_STORAGE_ENDPOINT
     DJANGO_MINIO_STORAGE_SECRET_KEY
+extras =
+    dev
 deps =
     factory-boy
     pytest
@@ -63,6 +65,8 @@ passenv =
     DJANGO_MINIO_STORAGE_ACCESS_KEY
     DJANGO_MINIO_STORAGE_ENDPOINT
     DJANGO_MINIO_STORAGE_SECRET_KEY
+extras =
+    dev
 commands =
     {envpython} ./manage.py makemigrations --check --dry-run
 


### PR DESCRIPTION
This has the benefit of slimming down the production install slightly.