### PR TITLE
Re-enable support for the old pip resolver

### DIFF
--- a/{{ cookiecutter.project_slug }}/setup.py
+++ b/{{ cookiecutter.project_slug }}/setup.py
@@ -40,7 +40,7 @@ setup(
         'django',
         'django-admin-display',
         'django-allauth',
-        'django-configurations',
+        'django-configurations[database,email]',
         'django-extensions',
         'django-filter',
         'django-oauth-toolkit',


### PR DESCRIPTION
This is necessary for Heroku.